### PR TITLE
Add Kafka server resources

### DIFF
--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -10,3 +10,16 @@ resource "aws_instance" "ec2" {
     Name = "ec2-linux"
   }
 }
+
+resource "aws_instance" "kafka" {
+  ami                         = "ami-0c02fb55956c7d316"
+  instance_type               = var.instance_type
+  subnet_id                   = aws_subnet.public.id
+  vpc_security_group_ids      = [aws_security_group.ec2_sg.id]
+  key_name                    = aws_key_pair.generated_key.key_name
+  associate_public_ip_address = true
+
+  tags = {
+    Name = "kafka-broker"
+  }
+}

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -55,6 +55,14 @@ resource "aws_security_group" "ec2_sg" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  ingress {
+    description = "Kafka"
+    from_port   = 9092
+    to_port     = 9092
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   egress {
     from_port   = 0
     to_port     = 0

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -7,3 +7,13 @@ output "private_key_path" {
   description = "Caminho da chave privada gerada"
   value       = local_file.private_key.filename
 }
+
+output "kafka_public_ip" {
+  description = "IP público do servidor Kafka"
+  value       = aws_instance.kafka.public_ip
+}
+
+output "kafka_bootstrap_servers" {
+  description = "Endpoint para conexão com o Kafka"
+  value       = "${aws_instance.kafka.public_ip}:9092"
+}


### PR DESCRIPTION
## Summary
- spin up a dedicated Kafka EC2 instance
- open the Kafka port in the security group
- expose Kafka connection details from Terraform outputs

## Testing
- `terraform fmt -recursive` *(fails: command not found)*
