### PR TITLE
Fix AMI variable usage

### DIFF
--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -1,5 +1,5 @@
 resource "aws_instance" "ec2" {
-  ami                         = "ami-0c02fb55956c7d316"
+  ami                         = var.ami
   instance_type               = var.instance_type
   subnet_id                   = aws_subnet.public.id
   vpc_security_group_ids      = [aws_security_group.ec2_sg.id]


### PR DESCRIPTION
## Summary
- use the `ami` variable for the EC2 instance in Terraform

## Testing
- `terraform fmt terraform/ec2.tf` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688930e23cac832294cda5624fac16c9